### PR TITLE
fixes build bug with g++ and struct declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Then compile the source using `g++`:
 ```bash
 g++ main.cpp -o bin.out \
   -std=c++17 \
-  -stdlib=libc++ \
   -lssl \
   -lcrypto \
   -I /usr/local/opt/openssl/include \

--- a/main.cpp
+++ b/main.cpp
@@ -143,9 +143,9 @@ struct license
   std::time_t created_at;
   std::time_t updated_at;
   std::vector<entitlement> entitlements;
-  product product;
-  policy policy;
-  user user;
+  struct product product;
+  struct policy policy;
+  struct user user;
 };
 
 // is_empty checks if the provided type is empty, used for structs.


### PR DESCRIPTION
Fixes
1. g++ build command
    ```g++: error: unrecognized command-line option ‘-stdlib=libc++’```
2. `struct` keywords were missing resulting in
```
main.cpp:146:11: error: declaration of ‘product license::product’ changes meaning of ‘product’ [-fpermissive]
  146 |   product product;
      |           ^~~~~~~
main.cpp:111:8: note: ‘product’ declared here as ‘struct product’
  111 | struct product
      |        ^~~~~~~
main.cpp:147:10: error: declaration of ‘policy license::policy’ changes meaning of ‘policy’ [-fpermissive]
  147 |   policy policy;
      |          ^~~~~~
main.cpp:118:8: note: ‘policy’ declared here as ‘struct policy’
  118 | struct policy
      |        ^~~~~~
main.cpp:148:8: error: declaration of ‘user license::user’ changes meaning of ‘user’ [-fpermissive]
  148 |   user user;
      |        ^~~~
main.cpp:125:8: note: ‘user’ declared here as ‘struct user’
  125 | struct user
```

With these two fixes, the example works fine.